### PR TITLE
groupByUnique

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: required
 jdk:
-- oraclejdk8
+  - openjdk8
 cache:
   directories:
   - "$HOME/.CommandBox"
@@ -15,9 +15,8 @@ env:
   global:
     secure: ytBE5/0yTki2SDLwIwVtLmheTxzKKe5hX4dl3/dqK9/W4BfFvyFfUMQgL9729tXXSKpANguyDDAEfhtHiO72HSyggOg9Ys5nsV/N42UzgOKpefKWyEQDJ2b6vZt/bbQ7CvpgXsvz72YrBKoHdrgGbdO46iLEkSdRsAXOyOre84ie68vT66yDpsrgWe21B23y8hUyG0jud3Vb9yg1VFEzdlgj08thHvxpmcnuLyBwiCZ36SBmJZImXpR78o/WT/1c8AJW2+wqwg3FzYkT+Gp8Ncckv3Z4nPsxAePZiLm9O7QLEwrK0OJzYtyR+MSW3aJPP5KMLA8pFi73LyJv5tvGDy2ftgiAS88FTO3MXgwbomiRAnvpLDRYo7CV0cKW05Y5xYQ4ro5nhV98SwNhsMWd+juYd4+d64/VUdC3mt+VoQU5AZSpQ3vf/1dCFO4PKM25n1qT773M1hzyQNO0wXTn07AJ0+W2PE3dcOO/ZUiAbmF943Fs1e/pjnfVrAEPJl17M63csvlrFo2CDiNbKeMZDcv5oVA0logv6eo+k/D/WVMyZ1LYFkx8xPW3B6LaolxMhiLAjgvOgAu6tOB7cOOwjS8kgejUlKd5H39CsZzbNiq4+gDo0e8lxufRCWv6cl6f8UPNQN8SWHc/ruBsIrAJIW30n2+wjot3EhEp26Nwri0=
 before_install:
-- sudo apt-key adv --keyserver keys.gnupg.net --recv 6DA70622
-- sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a
-  /etc/apt/sources.list.d/commandbox.list
+  - curl -fsSl https://downloads.ortussolutions.com/debs/gpg | sudo apt-key add -
+  - sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
 install:
 - sudo apt-get update && sudo apt-get --assume-yes install commandbox
 - box install

--- a/README.md
+++ b/README.md
@@ -585,7 +585,28 @@ collection.groupBy( "rank" );
 //     ]
 // }
 ```
+### groupByUnique
+Returns a struct similar to the groupBy() but different in that the values are expected to have a one-to-one relationship to the  key value. Items are therefore structs, not arrays of structs.
 
+The key can be the name of any property. The key values must be unique or it will throw an exception. 
+
+```cfc
+var collection = new models.Collection( [
+    { id = 1, name = "James T. Kirk", rank = "Captain", species = "Human" },
+    { id = 2, name = "Spock", rank = "Commander", species = "Vulcan" },
+    { id = 3, name = "Odo", rank = "Constable", species = "Changeling" },
+    { id = 4, name = "Jonathan Archer", rank = "Captain", species = "Human" }
+] );
+
+collection.groupByUnique( "id" );
+
+//{
+// 	"1" = { id = 1, name = "James T. Kirk", rank = "Captain", species = "Human" },
+// 	"2" = { id = 2, name = "Spock", rank = "Commander", species = "Vulcan" },
+// 	"3" = { id = 3, name = "Odo", rank = "Constable", species = "Changeling" },
+// 	"4" = { id = 4, name = "Jonathan Archer", rank = "Captain", species = "Human" }
+//}
+```
 ### serialize
 Returns the underlying collection serialized to JSON.  Can limit the serialized properties to a passed in comma-separated list or array of keys.
 

--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -394,7 +394,7 @@ component accessors="true" {
         return accumulator;
     }
 
-    public struct function groupBy( required string key, boolean forceLookup = false ) {
+    public struct function groupBy( required string key, boolean forceLookup = false, boolean unique = false ) {
         return this.reduce( function( acc, item ) {
             if ( ( isObject( item ) && structKeyExists( item, "get#key#" ) ) || forceLookup ) {
                 var value = invoke( item, "get#key#" );
@@ -405,25 +405,21 @@ component accessors="true" {
             if ( ! structKeyExists( acc, value ) ) {
                 acc[ value ] = [];
             }
-            arrayAppend( acc[ value ], item );
+            if(!unique){
+                arrayAppend( acc[ value ], item );
+            }else{
+                if( ! isArray( acc[ value ] ) ){
+                    throw(
+                        type = "KeyIsNotUnique",
+                        message="The groupBy key is not unique within the collection."
+                        );
+                }
+                acc[ value ] = item;
+            }
             return acc;
         }, {} );
     }
-    public struct function groupByUnique( required string key, boolean forceLookup = false ) {
-        return this.reduce( function( acc, item ) {
-            if ( ( isObject( item ) && structKeyExists( item, "get#key#" ) ) || forceLookup ) {
-                var value = invoke( item, "get#key#" );
-            }
-            else {
-                var value = item[ key ];
-            }
-            if ( ! structKeyExists( acc, value ) ) {
-                acc[ value ] = [];
-            }
-            acc[ value ] = item;
-            return acc;
-        }, {} );
-    }
+
 
     public numeric function sum( string field ) {
         var thisCollection = this;

--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -405,10 +405,10 @@ component accessors="true" {
             if ( ! structKeyExists( acc, value ) ) {
                 acc[ value ] = [];
             }
-            if(!unique){
+            if ( ! unique ) {
                 arrayAppend( acc[ value ], item );
-            }else{
-                if( ! isArray( acc[ value ] ) ){
+            } else {
+                if ( ! isArray( acc[ value ] ) ) {
                     throw(
                         type = "KeyIsNotUnique",
                         message="The groupBy key is not unique within the collection."
@@ -419,7 +419,9 @@ component accessors="true" {
             return acc;
         }, {} );
     }
-    public struct function groupByUnique( required string key, boolean forceLookup = false, boolean unique = true ) {
+
+    public struct function groupByUnique( required string key, boolean forceLookup = false ) {
+        arguments.unique = true;
         return this.groupBy( argumentCollection = arguments );
     }
 

--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -409,6 +409,21 @@ component accessors="true" {
             return acc;
         }, {} );
     }
+    public struct function groupByUnique( required string key, boolean forceLookup = false ) {
+        return this.reduce( function( acc, item ) {
+            if ( ( isObject( item ) && structKeyExists( item, "get#key#" ) ) || forceLookup ) {
+                var value = invoke( item, "get#key#" );
+            }
+            else {
+                var value = item[ key ];
+            }
+            if ( ! structKeyExists( acc, value ) ) {
+                acc[ value ] = [];
+            }
+            acc[ value ] = item;
+            return acc;
+        }, {} );
+    }
 
     public numeric function sum( string field ) {
         var thisCollection = this;

--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -419,7 +419,9 @@ component accessors="true" {
             return acc;
         }, {} );
     }
-
+    public struct function groupByUnique( required string key, boolean forceLookup = false, boolean unique = true ) {
+        return this.groupBy( argumentCollection = arguments );
+    }
 
     public numeric function sum( string field ) {
         var thisCollection = this;

--- a/tests/specs/non-static/CollectionSpec.cfc
+++ b/tests/specs/non-static/CollectionSpec.cfc
@@ -400,6 +400,39 @@ component extends="testbox.system.BaseSpec" {
 
                     expect( actual ).toBe( expected );
                 } );
+                it( "can group values by a given key and return a unique struct for each key", function() {
+                    var data = [
+                        { id = 1, name = "James T. Kirk", rank = "Captain", species = "Human" },
+                        { id = 2, name = "Spock", rank = "Commander", species = "Vulcan" },
+                        { id = 3, name = "Odo", rank = "Constable", species = "Changeling" },
+                        { id = 4, name = "Jonathan Archer", rank = "Captain", species = "Human" }
+                    ];
+                    var expected = {
+                        "1" = { id = 1, name = "James T. Kirk", rank = "Captain", species = "Human" },
+                        "2" = { id = 2, name = "Spock", rank = "Commander", species = "Vulcan" },
+                        "3" = { id = 3, name = "Odo", rank = "Constable", species = "Changeling" },
+                        "4" = { id = 4, name = "Jonathan Archer", rank = "Captain", species = "Human" }
+                    };
+
+                    var collection = new models.Collection( data );
+                    var actual = collection.groupBy( "id" ,false, true);
+
+                    expect( actual ).toBe( expected );
+                } );
+                it( "can group values by a given key and unique or throw error", function() {
+                    var data = [
+                        { id = 1, name = "James T. Kirk", rank = "Captain", species = "Human" },
+                        { id = 2, name = "Spock", rank = "Commander", species = "Vulcan" },
+                        { id = 3, name = "Odo", rank = "Constable", species = "Changeling" },
+                        { id = 4, name = "Jonathan Archer", rank = "Captain", species = "Human" }
+                    ];
+
+                    var collection = new models.Collection( data );
+
+                    expect( function() {
+                                var actual = collection.groupBy( "species" ,false, true);
+                            }  ).toThrow( "KeyIsNotUnique" );
+                } );
             } );
 
             it( "transpose", function() {

--- a/tests/specs/non-static/CollectionSpec.cfc
+++ b/tests/specs/non-static/CollectionSpec.cfc
@@ -415,7 +415,7 @@ component extends="testbox.system.BaseSpec" {
                     };
 
                     var collection = new models.Collection( data );
-                    var actual = collection.groupBy( "id" ,false, true);
+                    var actual = collection.groupByUnique( "id" );
 
                     expect( actual ).toBe( expected );
                 } );
@@ -430,7 +430,7 @@ component extends="testbox.system.BaseSpec" {
                     var collection = new models.Collection( data );
 
                     expect( function() {
-                                var actual = collection.groupBy( "species" ,false, true);
+                                var actual = collection.groupByUnique("species" );
                             }  ).toThrow( "KeyIsNotUnique" );
                 } );
             } );


### PR DESCRIPTION
So i have a use-case...thought maybe you would too.
Basically, suppose your component:singleton has within something you query often. Some sort of lookup service.
ex:  var userQry = qb.from('users').get()
variables.users =  collect( userQry ).groupBy('id');
Currently, the groupBy will result ["1": [{id:"1",col2:"",col3:""...} ,"2":...]
so if you have to write your lookup service as getUsersById(1)
return variables.users[1][0]...
groupByUnique will result in ["1": {id:"1",col2:"",col3:""...} ,"2":{cols}...]
so anywhere you can now just return variables.users[1] 
Nested array gone because we expect a record as struct, not an array of structs

So, whether its groupByKey or groupByUnique or whatever you name you like...or if this isn't collection worthy...thought i'd share.