### PR TITLE
Let .pluck() handle null values by nulling the returned key value

### DIFF
--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -84,7 +84,7 @@ component accessors="true" {
                 if ( isObject( item ) && structKeyExists( item, "get#keys[ 1 ]#" ) ) {
                     return invoke( item, "get#keys[ 1 ]#" );
                 }
-                return item.keyExists( keys[ 1 ] ) && !isNull( item[ keys[ 1 ] ] ) ? item[ keys[ 1 ] ] : javacast( "null", "" );
+                return structKeyExists( item, keys[ 1 ] ) && !isNull( item[ keys[ 1 ] ] ) ? item[ keys[ 1 ] ] : javacast( "null", "" );
             }
 
             // CF10 doesn't have arrayReduce
@@ -94,7 +94,7 @@ component accessors="true" {
                     obj[ key ] = invoke( item, "get#key#" );
                 }
                 else {
-                    obj[ key ] =  ( item.keyExists( key ) && !isNull( item[ key ] ) ) ? item[ key ] : javaCast( "null", "" );
+                    obj[ key ] =  ( structKeyExists( item, key ) && !isNull( item[ key ] ) ) ? item[ key ] : javaCast( "null", "" );
                 }
             }
             return obj;

--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -84,7 +84,7 @@ component accessors="true" {
                 if ( isObject( item ) && structKeyExists( item, "get#keys[ 1 ]#" ) ) {
                     return invoke( item, "get#keys[ 1 ]#" );
                 }
-                return item[ keys[ 1 ] ];
+                return item.keyExists( keys[ 1 ] ) && !isNull( item[ keys[ 1 ] ] ) ? item[ keys[ 1 ] ] : javacast( "null", "" );
             }
 
             // CF10 doesn't have arrayReduce
@@ -94,7 +94,7 @@ component accessors="true" {
                     obj[ key ] = invoke( item, "get#key#" );
                 }
                 else {
-                    obj[ key ] = item[ key ];
+                    obj[ key ] = ( !isNull( item[ key ] ) ? item[ key ] : javaCast( "null", "" ) );
                 }
             }
             return obj;

--- a/models/Collection.cfc
+++ b/models/Collection.cfc
@@ -94,7 +94,7 @@ component accessors="true" {
                     obj[ key ] = invoke( item, "get#key#" );
                 }
                 else {
-                    obj[ key ] = ( !isNull( item[ key ] ) ? item[ key ] : javaCast( "null", "" ) );
+                    obj[ key ] =  ( item.keyExists( key ) && !isNull( item[ key ] ) ) ? item[ key ] : javaCast( "null", "" );
                 }
             }
             return obj;

--- a/tests/specs/non-static/CollectionSpec.cfc
+++ b/tests/specs/non-static/CollectionSpec.cfc
@@ -221,7 +221,7 @@ component extends="testbox.system.BaseSpec" {
                     // convoluted tests to satisfy both Adobe and Lucee, since the null key won't exist in Adobe but will exist and just be null in Lucee
 
                     var itemWithNullValue = collectionWithNullValue[ 2 ];
-                    var keyDoesntExistOrIsNull = ( !itemWithNullValue.keyExists( "value" ) || isNull( itemWithNullValue[ "value" ] ) );
+                    var keyDoesntExistOrIsNull = ( !structKeyExists( itemWithNullValue, "value" ) || isNull( itemWithNullValue[ "value" ] ) );
                     
                     expect( keyDoesntExistOrIsNull ).toBeTrue();
                     

--- a/tests/specs/non-static/CollectionSpec.cfc
+++ b/tests/specs/non-static/CollectionSpec.cfc
@@ -195,6 +195,33 @@ component extends="testbox.system.BaseSpec" {
 
                     expect( collection.pluck( [ "value", "importance" ] ).get() ).toBe( expected );
                 } );
+
+                it( "can pluck an array of values from a collection and handle null values", function() {
+                    var data = [
+                        { label = "A", value = 1, importance = "10" },
+                        { label = "B", value = javaCast( "null", "" ), importance = "20" },
+                        { label = "C", value = 3, importance = "50" },
+                        { label = "D", value = 4, importance = "20" }
+                    ];
+                    var expected = [
+                        { value = 1, importance = "10" },
+                        { value = javaCast( "null", "" ), importance = "20" },
+                        { value = 3, importance = "50" },
+                        { value = 4, importance = "20" }
+                    ];
+
+                    var singleValueExpected = [
+                        [ 1, javaCast( "null", "" ), 3, 4 ]
+                    ];
+
+                    var collection = new models.Collection( data );
+
+                    expect( collection.pluck( [ "value", "importance" ] ).get() ).toBe( expected );
+                    
+                    var arrayWithNullValue =  collection.pluck( "value" ).get();
+                    
+                    expect( isNull( arrayWithNullValue[ 2 ] ) ).toBeTrue();
+                } );
             } );
 
             describe( "flatten", function() {

--- a/tests/specs/non-static/CollectionSpec.cfc
+++ b/tests/specs/non-static/CollectionSpec.cfc
@@ -216,11 +216,20 @@ component extends="testbox.system.BaseSpec" {
 
                     var collection = new models.Collection( data );
 
-                    expect( collection.pluck( [ "value", "importance" ] ).get() ).toBe( expected );
+                    var collectionWithNullValue = collection.pluck( [ "value", "importance" ] ).get();
                     
-                    var arrayWithNullValue =  collection.pluck( "value" ).get();
+                    // convoluted tests to satisfy both Adobe and Lucee, since the null key won't exist in Adobe but will exist and just be null in Lucee
+
+                    var itemWithNullValue = collectionWithNullValue[ 2 ];
+                    var keyDoesntExistOrIsNull = ( !itemWithNullValue.keyExists( "value" ) || isNull( itemWithNullValue[ "value" ] ) );
                     
-                    expect( isNull( arrayWithNullValue[ 2 ] ) ).toBeTrue();
+                    expect( keyDoesntExistOrIsNull ).toBeTrue();
+                    
+                    var arrayWithNullValue = collection.pluck( "value" ).get();
+                  
+                    var eleIsUndefinedOrIsJustNull = ( !arrayIsDefined( arrayWithNullValue, 2 ) || isNull( arrayWithNullValue[ 2 ] ) );
+
+                    expect( eleIsUndefinedOrIsJustNull ).toBeTrue();
                 } );
             } );
 


### PR DESCRIPTION
Add tests for .pluck() with one key and multiple keys
Relates to https://github.com/elpete/CFCollection/issues/28